### PR TITLE
do not run anything by default

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -34,6 +34,3 @@ namespace :systemd do
 		fetch(:systemd_use_sudo) ? sudo(*args) : execute(*args)
 	end
 end
-
-after "deploy:published", "systemd:daemon-reload"
-after "deploy:finished", "systemd:restart"


### PR DESCRIPTION
in certain setups a full restart isn't always required after deploy. same accounts for the daemon-reload; e.g. I'm using capistrano-foreman which exports systemd configuration. so the only time I have to reload the daemon is when I export new files. For that I use:

```
after :'foreman:export', :'systemd:daemon-reload'
```

also rolling restarts are not configurable when restart is always called.

With this configuration you can easily setup rolling restarts:
```
on :all, in: :groups, limit: 3, wait: 5 do
  within release_path do
    invoke :'systemd:restart'
  end
end
```

This also fixes https://github.com/CrBoy/capistrano-systemd/issues/2