### PR TITLE
Multiple units per host (using role or server configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ and do `cap production systemd:status` will show the status of your application.
 
 Run `cap -T systemd` to see the details of commands.
 
+If you don't want to default deploy hooks enabled, please use:
+```
+set :systemd_enable_deploy_hooks, false
+```
+
 ## Troubleshooting
 
 `sudo: no tty present and no askpass program specified`

--- a/README.md
+++ b/README.md
@@ -40,11 +40,6 @@ and do `cap production systemd:status` will show the status of your application.
 
 Run `cap -T systemd` to see the details of commands.
 
-If you don't want to default deploy hooks enabled, please use:
-```
-set :systemd_enable_deploy_hooks, false
-```
-
 ## Troubleshooting
 
 `sudo: no tty present and no askpass program specified`

--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ This gem lets you perform `systemctl` command on the target machine. Be sure tha
 Add the following example to your `config/deploy.rb`:
 
 ```
-set :systemd_unit, -> { "#{fetch :application}.target" }
 set :systemd_use_sudo, true
 set :systemd_roles, %w(app)
+```
+
+Add the following to your role or server config
+```
+role :app, ['server1.example.com'], systemd_units: ['unit1', 'unit2']
+OR
+server "server1.example.com", roles: [:app], systemd_units: ['unit1', 'unit2']
 ```
 
 and do `cap production systemd:status` will show the status of your application.

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -1,6 +1,5 @@
 namespace :load do
 	task :defaults do
-		set :systemd_enable_deploy_hooks, true
 		set :systemd_use_sudo, false
 		set :systemd_roles, %w(app)
 	end
@@ -39,7 +38,6 @@ namespace :systemd do
 	end
 end
 
-if fetch :systemd_enable_deploy_hooks
-	after "deploy:published", "systemd:daemon-reload"
-	after "deploy:finished", "systemd:restart"
-end
+after "deploy:published", "systemd:daemon-reload"
+after "deploy:finished", "systemd:restart"
+

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -1,5 +1,6 @@
 namespace :load do
 	task :defaults do
+		set :systemd_enable_deploy_hooks, true
 		set :systemd_use_sudo, false
 		set :systemd_roles, %w(app)
 	end
@@ -36,4 +37,9 @@ namespace :systemd do
 	def systemctl(*args)
 		fetch(:systemd_use_sudo) ? sudo(:systemctl, *args) : execute(:systemctl, *args)
 	end
+end
+
+if fetch :systemd_enable_deploy_hooks
+	after "deploy:published", "systemd:daemon-reload"
+	after "deploy:finished", "systemd:restart"
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -1,6 +1,5 @@
 namespace :load do
 	task :defaults do
-		set :systemd_unit, ->{ fetch :application }
 		set :systemd_use_sudo, false
 		set :systemd_roles, %w(app)
 	end
@@ -10,16 +9,20 @@ namespace :systemd do
 	%w(start stop restart enable disable).each do |command|
 		desc "#{command.capitalize} service"
 		task command do
-			on roles fetch :systemd_roles do
-				systemctl :"#{command}", fetch(:systemd_unit)
+			on roles fetch :systemd_roles do |host|
+				on host.properties.systemd_units do |systemd_unit|
+					systemctl :"#{command}", systemd_unit
+				end
 			end
 		end
 	end
 
 	desc "Show the status of service"
 	task :status do
-		on roles fetch :systemd_roles do
-			systemctl :status, fetch(:systemd_unit)
+		on roles fetch :systemd_roles do |host|
+			on host.properties.systemd_units do |systemd_unit|
+				systemctl :status, systemd_unit
+			end
 		end
 	end
 


### PR DESCRIPTION
This PR solves open issue #8 (Multiple units per application)
But also allows to have the multiple units be host (role or server) dependent

I've also added the default hooks again, they were were dropped in PR #5 (do not run anything by default)
Can't you use the clear actions trick, so solve your issue?
Rake::Task["systemd:daemon-reload"].clear_actions
